### PR TITLE
fix: update to latest rmcp API and add MSSQL URL format conversion

### DIFF
--- a/src/db_manager.rs
+++ b/src/db_manager.rs
@@ -7,6 +7,7 @@ use rbdc::db::{Connection, Driver};
 use rbdc::pool::{ConnectionManager, Pool};
 use rbdc_pool_fast::FastPool;
 use rbs::Value;
+use std::borrow::Cow;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -27,7 +28,7 @@ impl DatabaseType {
             Ok(DatabaseType::MySQL)
         } else if url.starts_with("postgres://") || url.starts_with("postgresql://") {
             Ok(DatabaseType::PostgreSQL)
-        } else if url.starts_with("mssql://") || url.starts_with("sqlserver://") {
+        } else if url.starts_with("mssql://") || url.starts_with("sqlserver://") || url.starts_with("jdbc:sqlserver://") {
             Ok(DatabaseType::MSSQL)
         } else {
             Err(anyhow!("Unsupported database URL format: {}", url))
@@ -41,10 +42,106 @@ pub struct DatabaseManager {
     db_type: DatabaseType,
 }
 
+/// Convert MSSQL URL format to JDBC format required by rbdc-mssql driver
+/// 
+/// rbdc-mssql expects JDBC format: jdbc:sqlserver://host:port;property=value
+/// But users typically provide: 
+/// - mssql://host:port/database?user=sa&password=pass
+/// - mssql://user:pass@host:port/database
+fn adapt_mssql_url(url: &str) -> Cow<'_, str> {
+    if url.starts_with("mssql://") || url.starts_with("sqlserver://") {
+        let without_prefix = url.trim_start_matches("mssql://")
+                               .trim_start_matches("sqlserver://");
+        
+        // Parse user:pass@host format
+        let (auth_part, rest) = if let Some(at_pos) = without_prefix.find('@') {
+            let (auth, rest) = without_prefix.split_at(at_pos);
+            let rest = &rest[1..]; // Remove @
+            (Some(auth), rest)
+        } else {
+            (None, without_prefix)
+        };
+        
+        // Extract username and password from auth part
+        let (username, password) = if let Some(auth) = auth_part {
+            if let Some((user, pass)) = auth.split_once(':') {
+                (Some(user), Some(pass))
+            } else {
+                (Some(auth), None)
+            }
+        } else {
+            (None, None)
+        };
+        
+        // Parse the rest of the URL
+        let parts: Vec<&str> = rest.splitn(2, '?').collect();
+        let host_port_db = parts[0];
+        
+        // Extract host:port and database
+        let (host_port, database) = if let Some(slash_pos) = host_port_db.rfind('/') {
+            let (hp, db) = host_port_db.split_at(slash_pos);
+            (hp, Some(&db[1..])) // Remove the leading slash
+        } else {
+            (host_port_db, None)
+        };
+        
+        // Start building JDBC URL
+        let mut jdbc_url = format!("jdbc:sqlserver://{}", host_port);
+        
+        // Add database if present
+        if let Some(db) = database {
+            jdbc_url.push_str(&format!(";Database={}", db));
+        }
+        
+        // Add username and password from auth part
+        if let Some(user) = username {
+            jdbc_url.push_str(&format!(";User={}", user));
+        }
+        if let Some(pass) = password {
+            jdbc_url.push_str(&format!(";Password={}", pass));
+        }
+        
+        // Convert query parameters from key=value&key=value to ;Key=value;Key=value
+        if parts.len() > 1 {
+            let params = parts[1];
+            for param in params.split('&') {
+                if let Some((key, value)) = param.split_once('=') {
+                    let key_capitalized = match key {
+                        "user" => "User",
+                        "password" => "Password", 
+                        "database" => "Database",
+                        _ => key,
+                    };
+                    jdbc_url.push(';');
+                    jdbc_url.push_str(key_capitalized);
+                    jdbc_url.push('=');
+                    jdbc_url.push_str(value);
+                }
+            }
+        }
+        
+        Cow::Owned(jdbc_url)
+    } else {
+        Cow::Borrowed(url)
+    }
+}
+
 impl DatabaseManager {
     /// Create a new database manager
     pub fn new(url: &str) -> Result<Self> {
+        log::debug!("Creating DatabaseManager with URL: {}", url);
         let db_type = DatabaseType::from_url(url)?;
+        log::debug!("Detected database type: {:?}", db_type);
+        
+        // Convert URL format for MSSQL BEFORE creating the driver
+        let adapted_url = match db_type {
+            DatabaseType::MSSQL => {
+                let converted = adapt_mssql_url(url);
+                log::debug!("MSSQL URL converted from '{}' to '{}'", url, converted);
+                converted
+            },
+            _ => Cow::Borrowed(url),
+        };
         
         let driver: Box<dyn Driver> = match db_type {
             DatabaseType::SQLite => Box::new(rbdc_sqlite::SqliteDriver {}),
@@ -53,7 +150,7 @@ impl DatabaseManager {
             DatabaseType::MSSQL => Box::new(rbdc_mssql::MssqlDriver {}),
         };
 
-        let manager = ConnectionManager::new(driver, url)?;
+        let manager = ConnectionManager::new(driver, adapted_url.as_ref())?;
         let pool = FastPool::new(manager)?;
         
         Ok(Self {

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,10 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Create database manager
     let db_manager = DatabaseManager::new(&args.database_url)
-        .map_err(|e| anyhow::Error::msg(e.to_string()))?;
+        .map_err(|e| {
+            error!("Failed to create database manager: {}", e);
+            anyhow::Error::msg(e.to_string())
+        })?;
     
     // Configure connection pool
     db_manager.configure_pool(args.max_connections, args.timeout).await;


### PR DESCRIPTION
## Description

This PR updates the code to work with the latest rmcp SDK API changes and fixes MSSQL connection errors.

Closes #1

## Changes

### 1. Updated rmcp API usage

- Replace deprecated `#[tool(tool_box)]` with `#[tool_router]`
- Add `tool_router` field to `RbdcDatabaseHandler`
- Update tool method parameters to use `Parameters<T>` wrapper
- Replace second `#[tool(tool_box)]` with `#[tool_handler]`
- Update imports to include necessary types

### 2. Fixed MSSQL connection format

- Add `adapt_mssql_url` function to convert standard URLs to JDBC format
- Support multiple URL formats:
  - `mssql://user:pass@host:port/database`
  - `mssql://host:port/database?user=sa&password=pass`
  - `sqlserver://...` (alternative prefix)
  - `jdbc:sqlserver://...` (direct JDBC format)
- Update `DatabaseType::from_url` to recognize JDBC format

## Testing

Tested on Ubuntu 24.04.2 LTS (WSL2) with all supported databases:

| Database   | Connection | SQL Operations | MCP Protocol |
| ---------- | :--------: | :------------: | :----------: |
| SQLite     |     ✅      |       ✅        |      ✅       |
| MySQL      |     ✅      |       ✅        |      ✅       |
| PostgreSQL |     ✅      |       ✅        |      ✅       |
| MSSQL      |     ✅      |       ✅        |      ✅       |

### Test Details

- ✅ Code compiles successfully with `cargo build --release`
- ✅ All database connections tested and working
- ✅ MCP protocol operations verified (db_status, sql_query, sql_exec)
- ✅ MSSQL URL conversion tested with multiple formats

### MSSQL URL Conversion Example

- Input: `mssql://sa:TestPass123@localhost:1433/testdb`
- Output: `jdbc:sqlserver://localhost:1433;Database=testdb;User=sa;Password=TestPass123`