### PR TITLE
fix MCP startup timeout and update protocol version to LATEST

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 .vscode/
 /.vscode
 '.vscode'
+.codex/
 /.github
 
 
@@ -29,5 +30,4 @@ Cargo.lock
 
 #mac
 *.DS_Store
-
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rbdc-mcp"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 description = "MCP (Model Context Protocol) Server for RBDC - Execute SQL queries and modifications"
 authors = ["rbdc team"]

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ In Claude Desktop, try asking:
 | `--max-connections` | Maximum connection pool size | `1` |
 | `--timeout` | Connection timeout (seconds) | `30` |
 | `--log-level` | Log level (error/warn/info/debug) | `info` |
+| `--read-only` | Enforce read-only mode (rejects `sql_exec`) | `false` |
 
 ## 🛠️ Available Tools
 

--- a/README.md
+++ b/README.md
@@ -132,13 +132,23 @@ In Claude Desktop, try asking:
 | `--max-connections` | Maximum connection pool size | `1` |
 | `--timeout` | Connection timeout (seconds) | `30` |
 | `--log-level` | Log level (error/warn/info/debug) | `info` |
-| `--read-only` | Enforce read-only mode (rejects `sql_exec`) | `false` |
+| `--read-only` | Enforce read-only mode and abort startup unless the current session can be validated as read-only. | `false` |
 
 ## 🛠️ Available Tools
 
-- **`sql_query`**: Execute SELECT queries safely
-- **`sql_exec`**: Execute INSERT/UPDATE/DELETE operations
+- **`sql_query`**: Execute single read-only SQL queries safely
+- **`sql_exec`**: Execute INSERT/UPDATE/DELETE operations when the server is not in read-only mode
 - **`db_status`**: Check connection pool status
+
+## Read-Only Mode
+
+`--read-only` is intended to make the database connection itself read-only, not just hide one tool. Startup now fails if the server cannot validate the current session as read-only for the selected engine.
+
+- **SQLite**: use a URI such as `sqlite://./database.db?mode=ro`. The server rejects `--read-only` if the SQLite URL is not explicitly read-only.
+- **PostgreSQL**: the server validates `SHOW transaction_read_only` and aborts startup unless it is `on`.
+- **MySQL**: the server validates `@@session.transaction_read_only` (or `@@session.tx_read_only` on older servers) and aborts startup unless it is enabled.
+- **MSSQL**: the server validates `DATABASEPROPERTYEX(DB_NAME(), 'Updateability')` and aborts startup unless the current database reports `READ_ONLY`.
+- **`sql_query`** always accepts only a single read-only SQL statement and rejects multi-statement or mutating input.
 
 ## 📸 Screenshots
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -136,6 +136,7 @@ cargo install --git https://github.com/rbatis/rbdc-mcp.git
 | `--max-connections` | 最大连接池大小 | `1` |
 | `--timeout` | 连接超时时间（秒） | `30` |
 | `--log-level` | 日志级别（error/warn/info/debug） | `info` |
+| `--read-only` | 强制只读模式（拒绝 `sql_exec`） | `false` |
 
 ## 🛠️ 可用工具
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -136,13 +136,23 @@ cargo install --git https://github.com/rbatis/rbdc-mcp.git
 | `--max-connections` | 最大连接池大小 | `1` |
 | `--timeout` | 连接超时时间（秒） | `30` |
 | `--log-level` | 日志级别（error/warn/info/debug） | `info` |
-| `--read-only` | 强制只读模式（拒绝 `sql_exec`） | `false` |
+| `--read-only` | 强制只读模式；如果当前数据库会话无法验证为只读，启动会直接失败。 | `false` |
 
 ## 🛠️ 可用工具
 
-- **`sql_query`**: 安全执行SELECT查询
-- **`sql_exec`**: 执行INSERT/UPDATE/DELETE操作
+- **`sql_query`**: 安全执行单条只读 SQL 查询
+- **`sql_exec`**: 在非只读模式下执行 INSERT/UPDATE/DELETE 操作
 - **`db_status`**: 检查连接池状态
+
+## 只读模式
+
+`--read-only` 的目标是让数据库连接本身具备只读约束，而不仅仅是隐藏某个工具。现在如果服务器无法验证当前会话确实是只读，会在启动阶段直接失败。
+
+- **SQLite**: 使用类似 `sqlite://./database.db?mode=ro` 的 URI。如果 SQLite URL 没有显式只读参数，服务器会拒绝在 `--read-only` 模式下启动。
+- **PostgreSQL**: 服务器会检查 `SHOW transaction_read_only`，只有结果为 `on` 才允许启动。
+- **MySQL**: 服务器会检查 `@@session.transaction_read_only`（旧版本则回退到 `@@session.tx_read_only`），只有启用后才允许启动。
+- **MSSQL**: 服务器会检查 `DATABASEPROPERTYEX(DB_NAME(), 'Updateability')`，只有当前数据库返回 `READ_ONLY` 才允许启动。
+- **`sql_query`** 始终只接受单条只读 SQL 语句，并拒绝多语句或带写操作的输入。
 
 ## 📸 截图
 

--- a/src/db_manager.rs
+++ b/src/db_manager.rs
@@ -9,6 +9,7 @@ use rbdc_pool_fast::FastPool;
 use rbs::Value;
 use std::sync::Arc;
 use std::time::Duration;
+use crate::sql_guard::is_read_only_sql;
 
 /// Supported database types
 #[derive(Debug, Clone)]
@@ -73,6 +74,10 @@ impl DatabaseManager {
 
     /// Execute query and return result set
     pub async fn execute_query(&self, sql: &str, params: Vec<Value>) -> Result<Value> {
+        if !is_read_only_sql(sql) {
+            return Err(anyhow!("Read-only query validation failed"));
+        }
+
         let mut conn = self.pool.get().await
             .map_err(|e| anyhow!("Failed to get database connection: {}", e))?;
         let result = conn.get_values(sql, params).await

--- a/src/db_manager.rs
+++ b/src/db_manager.rs
@@ -1,15 +1,15 @@
 //! Database connection manager
-//! 
+//!
 //! Responsible for managing different types of database connections
 
-use anyhow::{Ok, Result, anyhow};
+use crate::sql_guard::is_read_only_sql;
+use anyhow::{anyhow, Result};
 use rbdc::db::{Connection, Driver};
 use rbdc::pool::{ConnectionManager, Pool};
 use rbdc_pool_fast::FastPool;
 use rbs::Value;
 use std::sync::Arc;
 use std::time::Duration;
-use crate::sql_guard::is_read_only_sql;
 
 /// Supported database types
 #[derive(Debug, Clone)]
@@ -17,7 +17,7 @@ pub enum DatabaseType {
     SQLite,
     MySQL,
     PostgreSQL,
-    MSSQL,
+    Mssql,
 }
 
 impl DatabaseType {
@@ -26,10 +26,16 @@ impl DatabaseType {
             Ok(DatabaseType::SQLite)
         } else if url.starts_with("mysql://") {
             Ok(DatabaseType::MySQL)
-        } else if url.starts_with("pg://") || url.starts_with("postgres://") || url.starts_with("postgresql://") {
+        } else if url.starts_with("pg://")
+            || url.starts_with("postgres://")
+            || url.starts_with("postgresql://")
+        {
             Ok(DatabaseType::PostgreSQL)
-        } else if url.starts_with("mssql://") || url.starts_with("sqlserver://") || url.starts_with("jdbc:sqlserver://") {
-            Ok(DatabaseType::MSSQL)
+        } else if url.starts_with("mssql://")
+            || url.starts_with("sqlserver://")
+            || url.starts_with("jdbc:sqlserver://")
+        {
+            Ok(DatabaseType::Mssql)
         } else {
             Err(anyhow!("Unsupported database URL format: {}", url))
         }
@@ -40,36 +46,41 @@ impl DatabaseType {
 pub struct DatabaseManager {
     pool: Arc<FastPool>,
     db_type: DatabaseType,
+    read_only: bool,
 }
-
 
 impl DatabaseManager {
     /// Create a new database manager
-    pub fn new(url: &str) -> Result<Self> {
+    pub fn new(url: &str, read_only: bool) -> Result<Self> {
         log::debug!("Creating DatabaseManager with URL: {}", url);
         let db_type = DatabaseType::from_url(url)?;
         log::debug!("Detected database type: {:?}", db_type);
+
+        validate_read_only_configuration(&db_type, url, read_only)?;
 
         let driver: Box<dyn Driver> = match db_type {
             DatabaseType::SQLite => Box::new(rbdc_sqlite::SqliteDriver {}),
             DatabaseType::MySQL => Box::new(rbdc_mysql::MysqlDriver {}),
             DatabaseType::PostgreSQL => Box::new(rbdc_pg::PgDriver {}),
-            DatabaseType::MSSQL => Box::new(rbdc_mssql::MssqlDriver {}),
+            DatabaseType::Mssql => Box::new(rbdc_mssql::MssqlDriver {}),
         };
 
-        let manager = ConnectionManager::new(driver, url.as_ref())?;
+        let manager = ConnectionManager::new(driver, url)?;
         let pool = FastPool::new(manager)?;
-        
+
         Ok(Self {
             pool: Arc::new(pool),
             db_type,
+            read_only,
         })
     }
 
     /// Configure connection pool parameters
     pub async fn configure_pool(&self, max_connections: u64, timeout_seconds: u64) {
         self.pool.set_max_open_conns(max_connections).await;
-        self.pool.set_timeout(Some(Duration::from_secs(timeout_seconds))).await;
+        self.pool
+            .set_timeout(Some(Duration::from_secs(timeout_seconds)))
+            .await;
     }
 
     /// Execute query and return result set
@@ -78,21 +89,41 @@ impl DatabaseManager {
             return Err(anyhow!("Read-only query validation failed"));
         }
 
-        let mut conn = self.pool.get().await
+        let mut conn = self
+            .pool
+            .get()
+            .await
             .map_err(|e| anyhow!("Failed to get database connection: {}", e))?;
-        let result = conn.get_values(sql, params).await
+        let result = conn
+            .get_values(sql, params)
+            .await
             .map_err(|e| anyhow!("Query execution failed: {}", e))?;
         Ok(result)
     }
 
     /// Execute modification operations (INSERT, UPDATE, DELETE, etc.)
-    pub async fn execute_modification(&self, sql: &str, params: Vec<Value>) -> Result<serde_json::Value> {
-        let mut conn = self.pool.get().await
+    pub async fn execute_modification(
+        &self,
+        sql: &str,
+        params: Vec<Value>,
+    ) -> Result<serde_json::Value> {
+        if self.read_only {
+            return Err(anyhow!(
+                "Read-only mode blocks SQL modifications. Use a database connection with read-only access and submit only read-only queries."
+            ));
+        }
+
+        let mut conn = self
+            .pool
+            .get()
+            .await
             .map_err(|e| anyhow!("Failed to get database connection: {}", e))?;
-            
-        let result = conn.exec(sql, params).await
+
+        let result = conn
+            .exec(sql, params)
+            .await
             .map_err(|e| anyhow!("Modification operation failed: {}", e))?;
-            
+
         // Return JSON representation of operation result
         Ok(serde_json::json!({
             "rows_affected": result.rows_affected,
@@ -105,25 +136,292 @@ impl DatabaseManager {
         &self.db_type
     }
 
+    /// Whether server read-only mode is enabled
+    pub fn read_only_enabled(&self) -> bool {
+        self.read_only
+    }
+
+    /// Human-readable startup notice for database-specific read-only expectations
+    pub fn read_only_startup_notice(&self) -> Option<&'static str> {
+        if !self.read_only {
+            return None;
+        }
+
+        match self.db_type {
+            DatabaseType::SQLite => Some(
+                "Read-only mode enabled with SQLite URI validation. Keep using a sqlite URL configured with mode=ro."
+            ),
+            DatabaseType::MySQL => Some(
+                "Read-only mode enabled. For MySQL, the real safety boundary is a database user without write privileges."
+            ),
+            DatabaseType::PostgreSQL => Some(
+                "Read-only mode enabled. For PostgreSQL, the real safety boundary is a read-only role or equivalent database privileges."
+            ),
+            DatabaseType::Mssql => Some(
+                "Read-only mode enabled. For MSSQL, the real safety boundary is a login/user with reader-only permissions."
+            ),
+        }
+    }
+
+    /// Validate that the connected session is provably read-only.
+    pub async fn validate_read_only_session(&self) -> Result<()> {
+        if !self.read_only {
+            return Ok(());
+        }
+
+        match self.db_type {
+            DatabaseType::SQLite => self.validate_sqlite_read_only_session().await,
+            DatabaseType::MySQL => self.validate_mysql_read_only_session().await,
+            DatabaseType::PostgreSQL => self.validate_postgres_read_only_session().await,
+            DatabaseType::Mssql => self.validate_mssql_read_only_session().await,
+        }
+    }
+
     /// Get connection pool state
     pub async fn get_pool_state(&self) -> serde_json::Value {
         let state = self.pool.state().await;
         let mut result = serde_json::json!(state);
         // Add database type information
         if let Some(obj) = result.as_object_mut() {
-            obj.insert("database_type".to_string(), serde_json::json!(format!("{:?}", self.database_type())));
+            obj.insert(
+                "database_type".to_string(),
+                serde_json::json!(format!("{:?}", self.database_type())),
+            );
+            obj.insert("read_only".to_string(), serde_json::json!(self.read_only));
         }
         result
     }
 
     /// Test database connection
     pub async fn test_connection(&self) -> Result<()> {
-        let mut conn = self.pool.get().await
+        let mut conn = self
+            .pool
+            .get()
+            .await
             .map_err(|e| anyhow!("Failed to get database connection: {}", e))?;
-            
-        conn.ping().await
+
+        conn.ping()
+            .await
             .map_err(|e| anyhow!("Database connection test failed: {}", e))?;
-            
+
         Ok(())
     }
-} 
+
+    async fn validate_sqlite_read_only_session(&self) -> Result<()> {
+        // SQLite read-only mode is validated at startup by requiring mode=ro in the connection URI.
+        Ok(())
+    }
+
+    async fn validate_mysql_read_only_session(&self) -> Result<()> {
+        let value = match self
+            .fetch_session_scalar("SELECT @@session.transaction_read_only AS read_only")
+            .await
+        {
+            Ok(value) => value,
+            Err(_) => {
+                self.fetch_session_scalar("SELECT @@session.tx_read_only AS read_only")
+                    .await?
+            }
+        };
+
+        if scalar_value_is_enabled(&value) {
+            Ok(())
+        } else {
+            Err(anyhow!(
+                "Read-only mode requires a verifiably read-only MySQL session. Expected @@session.transaction_read_only = 1."
+            ))
+        }
+    }
+
+    async fn validate_postgres_read_only_session(&self) -> Result<()> {
+        let value = self
+            .fetch_session_scalar("SHOW transaction_read_only")
+            .await?;
+
+        if scalar_value_is_enabled(&value) {
+            Ok(())
+        } else {
+            Err(anyhow!(
+                "Read-only mode requires a verifiably read-only PostgreSQL session. Expected transaction_read_only = on."
+            ))
+        }
+    }
+
+    async fn validate_mssql_read_only_session(&self) -> Result<()> {
+        let value = self
+            .fetch_session_scalar(
+                "SELECT CAST(DATABASEPROPERTYEX(DB_NAME(), 'Updateability') AS NVARCHAR(60)) AS updateability",
+            )
+            .await?;
+
+        if scalar_value_matches(&value, &["READ_ONLY"]) {
+            Ok(())
+        } else {
+            Err(anyhow!(
+                "Read-only mode requires a verifiably read-only MSSQL database. Expected DATABASEPROPERTYEX(DB_NAME(), 'Updateability') = READ_ONLY."
+            ))
+        }
+    }
+
+    async fn fetch_session_scalar(&self, sql: &str) -> Result<Value> {
+        let mut conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| anyhow!("Failed to get database connection: {}", e))?;
+
+        let rows = conn
+            .get_values(sql, vec![])
+            .await
+            .map_err(|e| anyhow!("Read-only session validation query failed: {}", e))?;
+
+        first_scalar_from_rows(&rows).ok_or_else(|| {
+            anyhow!(
+                "Read-only session validation query returned an unexpected result shape: {}",
+                rows
+            )
+        })
+    }
+}
+
+fn validate_read_only_configuration(
+    db_type: &DatabaseType,
+    url: &str,
+    read_only: bool,
+) -> Result<()> {
+    if !read_only {
+        return Ok(());
+    }
+
+    match db_type {
+        DatabaseType::SQLite => {
+            if !sqlite_url_is_explicitly_read_only(url) {
+                return Err(anyhow!(
+                    "Read-only mode for SQLite requires an explicit read-only URI, for example sqlite://path/to/database.db?mode=ro"
+                ));
+            }
+        }
+        DatabaseType::MySQL | DatabaseType::PostgreSQL | DatabaseType::Mssql => {}
+    }
+
+    Ok(())
+}
+
+fn sqlite_url_is_explicitly_read_only(url: &str) -> bool {
+    let lowercase = url.to_ascii_lowercase();
+    lowercase.contains("?mode=ro") || lowercase.contains("&mode=ro")
+}
+
+fn first_scalar_from_rows(rows: &Value) -> Option<Value> {
+    let first_row = rows.as_array()?.first()?;
+
+    if let Some(map) = first_row.as_map() {
+        if let Some((_, value)) = map.into_iter().next() {
+            return Some(value.clone());
+        }
+    }
+
+    Some(first_row.clone())
+}
+
+fn scalar_value_is_enabled(value: &Value) -> bool {
+    if let Some(flag) = value.as_bool() {
+        return flag;
+    }
+
+    if let Some(number) = value.as_i64() {
+        return number != 0;
+    }
+
+    if let Some(text) = value.as_str() {
+        return matches!(
+            text.trim().to_ascii_lowercase().as_str(),
+            "1" | "on" | "true" | "read_only"
+        );
+    }
+
+    false
+}
+
+fn scalar_value_matches(value: &Value, allowed: &[&str]) -> bool {
+    value.as_str().is_some_and(|text| {
+        allowed
+            .iter()
+            .any(|candidate| text.trim().eq_ignore_ascii_case(candidate))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        first_scalar_from_rows, scalar_value_is_enabled, scalar_value_matches,
+        sqlite_url_is_explicitly_read_only, validate_read_only_configuration, DatabaseType,
+    };
+    use rbs::{value::map::ValueMap, Value};
+
+    #[test]
+    fn from_url_accepts_postgres_scheme() {
+        let db_type = DatabaseType::from_url("postgres://user:pass@localhost/db").unwrap();
+        assert!(matches!(db_type, DatabaseType::PostgreSQL));
+    }
+
+    #[test]
+    fn sqlite_read_only_url_detection_accepts_query_parameter() {
+        assert!(sqlite_url_is_explicitly_read_only(
+            "sqlite://./db.sqlite?mode=ro"
+        ));
+        assert!(sqlite_url_is_explicitly_read_only(
+            "sqlite://./db.sqlite?cache=shared&mode=ro"
+        ));
+    }
+
+    #[test]
+    fn sqlite_read_only_url_detection_rejects_plain_sqlite_url() {
+        assert!(!sqlite_url_is_explicitly_read_only("sqlite://./db.sqlite"));
+    }
+
+    #[test]
+    fn validate_read_only_configuration_requires_explicit_sqlite_mode() {
+        let db_type = DatabaseType::SQLite;
+        let result = validate_read_only_configuration(&db_type, "sqlite://./db.sqlite", true);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn validate_read_only_configuration_allows_non_sqlite_with_read_only_flag() {
+        let db_type = DatabaseType::MySQL;
+        let result =
+            validate_read_only_configuration(&db_type, "mysql://user:pass@localhost/db", true);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn first_scalar_from_rows_reads_first_map_value() {
+        let mut map = ValueMap::new();
+        map["read_only"] = Value::Bool(true);
+        let rows = Value::Array(vec![Value::Map(map)]);
+
+        let value = first_scalar_from_rows(&rows).unwrap();
+        assert_eq!(value.as_bool(), Some(true));
+    }
+
+    #[test]
+    fn scalar_value_is_enabled_accepts_bool_number_and_text() {
+        assert!(scalar_value_is_enabled(&Value::Bool(true)));
+        assert!(scalar_value_is_enabled(&Value::I64(1)));
+        assert!(scalar_value_is_enabled(&Value::String("on".to_string())));
+        assert!(!scalar_value_is_enabled(&Value::String("off".to_string())));
+    }
+
+    #[test]
+    fn scalar_value_matches_compares_case_insensitively() {
+        assert!(scalar_value_matches(
+            &Value::String("READ_ONLY".to_string()),
+            &["read_only"]
+        ));
+        assert!(!scalar_value_matches(
+            &Value::String("READ_WRITE".to_string()),
+            &["read_only"]
+        ));
+    }
+}

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 use crate::db_manager::DatabaseManager;
+use crate::sql_guard::is_read_only_sql;
 
 use rmcp::{
     ErrorData as McpError, ServerHandler,
@@ -12,6 +13,7 @@ use rmcp::{
 #[derive(Clone)]
 pub struct RbdcDatabaseHandler {
     db_manager: Arc<DatabaseManager>,
+    read_only: bool,
     tool_router: ToolRouter<RbdcDatabaseHandler>,
 }
 
@@ -36,9 +38,10 @@ pub struct SqlExecParams {
 // Use tool_router macro to generate the tool router
 #[tool_router]
 impl RbdcDatabaseHandler {
-    pub fn new(db_manager: Arc<DatabaseManager>) -> Self {
+    pub fn new(db_manager: Arc<DatabaseManager>, read_only: bool) -> Self {
         Self {
             db_manager,
+            read_only,
             tool_router: Self::tool_router(),
         }
     }
@@ -55,6 +58,13 @@ impl RbdcDatabaseHandler {
         _context: RequestContext<RoleServer>,
         Parameters(params): Parameters<SqlQueryParams>,
     ) -> Result<CallToolResult, McpError> {
+        if !is_read_only_sql(&params.sql) {
+            return Err(McpError::invalid_params(
+                "sql_query only accepts single read-only SQL statements".to_string(),
+                None,
+            ));
+        }
+
         // Convert parameter types from serde_json::Value to rbs::Value
         let rbs_params = self.convert_params(&params.params);
 
@@ -74,6 +84,13 @@ impl RbdcDatabaseHandler {
         _context: RequestContext<RoleServer>,
         Parameters(params): Parameters<SqlExecParams>,
     ) -> Result<CallToolResult, McpError> {
+        if self.read_only {
+            return Err(McpError::invalid_params(
+                "sql_exec is disabled when server is started with --read-only".to_string(),
+                None,
+            ));
+        }
+
         // Convert parameter types from serde_json::Value to rbs::Value
         let rbs_params = self.convert_params(&params.params);
 
@@ -126,4 +143,4 @@ impl ServerHandler for RbdcDatabaseHandler {
     ) -> Result<InitializeResult, McpError> {
         Ok(self.get_info())
     }
-} 
+}

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,19 +1,18 @@
-use std::sync::Arc;
 use crate::db_manager::DatabaseManager;
 use crate::sql_guard::is_read_only_sql;
+use std::sync::Arc;
 
 use rmcp::{
-    ErrorData as McpError, ServerHandler,
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
-    model::*, schemars,
+    model::*,
+    schemars,
     service::{RequestContext, RoleServer},
-    tool, tool_handler, tool_router,
+    tool, tool_handler, tool_router, ErrorData as McpError, ServerHandler,
 };
 
 #[derive(Clone)]
 pub struct RbdcDatabaseHandler {
     db_manager: Arc<DatabaseManager>,
-    read_only: bool,
     tool_router: ToolRouter<RbdcDatabaseHandler>,
 }
 
@@ -38,16 +37,16 @@ pub struct SqlExecParams {
 // Use tool_router macro to generate the tool router
 #[tool_router]
 impl RbdcDatabaseHandler {
-    pub fn new(db_manager: Arc<DatabaseManager>, read_only: bool) -> Self {
+    pub fn new(db_manager: Arc<DatabaseManager>) -> Self {
         Self {
             db_manager,
-            read_only,
             tool_router: Self::tool_router(),
         }
     }
 
     fn convert_params(&self, params: &[serde_json::Value]) -> Vec<rbs::Value> {
-        params.iter()
+        params
+            .iter()
             .map(|v| serde_json::from_value(v.clone()).unwrap_or_default())
             .collect()
     }
@@ -70,11 +69,15 @@ impl RbdcDatabaseHandler {
 
         match self.db_manager.execute_query(&params.sql, rbs_params).await {
             Ok(results) => {
-                let content = Content::json(results)
-                    .map_err(|e| McpError::internal_error(format!("Result serialization failed: {}", e), None))?;
+                let content = Content::json(results).map_err(|e| {
+                    McpError::internal_error(format!("Result serialization failed: {}", e), None)
+                })?;
                 Ok(CallToolResult::success(vec![content]))
             }
-            Err(e) => Err(McpError::internal_error(format!("SQL query failed: {}", e), None))
+            Err(e) => Err(McpError::internal_error(
+                format!("SQL query failed: {}", e),
+                None,
+            )),
         }
     }
 
@@ -84,9 +87,9 @@ impl RbdcDatabaseHandler {
         _context: RequestContext<RoleServer>,
         Parameters(params): Parameters<SqlExecParams>,
     ) -> Result<CallToolResult, McpError> {
-        if self.read_only {
+        if self.db_manager.read_only_enabled() {
             return Err(McpError::invalid_params(
-                "sql_exec is disabled when server is started with --read-only".to_string(),
+                "Read-only mode blocks SQL modifications. Configure the database itself for read-only access and use sql_query only for single read-only statements.".to_string(),
                 None,
             ));
         }
@@ -94,13 +97,21 @@ impl RbdcDatabaseHandler {
         // Convert parameter types from serde_json::Value to rbs::Value
         let rbs_params = self.convert_params(&params.params);
 
-        match self.db_manager.execute_modification(&params.sql, rbs_params).await {
+        match self
+            .db_manager
+            .execute_modification(&params.sql, rbs_params)
+            .await
+        {
             Ok(result) => {
-                let content = Content::json(result)
-                    .map_err(|e| McpError::internal_error(format!("Result serialization failed: {}", e), None))?;
+                let content = Content::json(result).map_err(|e| {
+                    McpError::internal_error(format!("Result serialization failed: {}", e), None)
+                })?;
                 Ok(CallToolResult::success(vec![content]))
             }
-            Err(e) => Err(McpError::internal_error(format!("SQL execution failed: {}", e), None))
+            Err(e) => Err(McpError::internal_error(
+                format!("SQL execution failed: {}", e),
+                None,
+            )),
         }
     }
 
@@ -110,8 +121,9 @@ impl RbdcDatabaseHandler {
         _context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
         let status = self.db_manager.get_pool_state().await;
-        let content = Content::json(status)
-            .map_err(|e| McpError::internal_error(format!("Status serialization failed: {}", e), None))?;
+        let content = Content::json(status).map_err(|e| {
+            McpError::internal_error(format!("Status serialization failed: {}", e), None)
+        })?;
         Ok(CallToolResult::success(vec![content]))
     }
 }
@@ -120,7 +132,7 @@ impl RbdcDatabaseHandler {
 impl ServerHandler for RbdcDatabaseHandler {
     fn get_info(&self) -> ServerInfo {
         ServerInfo {
-            protocol_version: ProtocolVersion::V_2024_11_05,
+            protocol_version: ProtocolVersion::LATEST,
             capabilities: ServerCapabilities::builder()
                 .enable_tools()
                 .build(),
@@ -132,7 +144,7 @@ impl ServerHandler for RbdcDatabaseHandler {
                 title: None,
                 website_url: None,
             },
-            instructions: Some("RBDC database MCP server providing SQL query, execution and status check tools. Supports sql_query (query), sql_exec (modification) and db_status (status check) tools.".to_string()),
+            instructions: Some("RBDC database MCP server providing SQL query, execution and status check tools. sql_query accepts only single read-only SQL statements. When the server starts with --read-only, the database connection itself should also be configured for read-only access.".to_string()),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use tracing_subscriber::{EnvFilter};
 
 mod db_manager;
 mod handler;
+mod sql_guard;
 
 use crate::db_manager::DatabaseManager;
 use crate::handler::RbdcDatabaseHandler;
@@ -31,6 +32,10 @@ struct Args {
     /// Log level
     #[arg(long, default_value = "info")]
     log_level: String,
+
+    /// Enforce read-only server mode (blocks sql_exec)
+    #[arg(long, default_value_t = false)]
+    read_only: bool,
 }
 
 #[tokio::main]
@@ -50,6 +55,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     info!("Starting RBDC MCP Server");
     info!("Database URL: {}", args.database_url);
+    info!("Read-only mode: {}", args.read_only);
 
     // Create database manager
     let db_manager = DatabaseManager::new(&args.database_url)
@@ -68,7 +74,7 @@ async fn main() -> Result<(), anyhow::Error> {
     info!("Database connection test successful");
 
     // Create RBDC database handler
-    let handler = RbdcDatabaseHandler::new(Arc::new(db_manager));
+    let handler = RbdcDatabaseHandler::new(Arc::new(db_manager), args.read_only);
 
     info!("Starting RBDC MCP Server...");
     

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
 use clap::Parser;
 use std::sync::Arc;
-use tracing::{info, error};
-use tracing_subscriber::{EnvFilter};
+use tracing::{error, info};
+use tracing_subscriber::EnvFilter;
 
 mod db_manager;
 mod handler;
@@ -10,7 +10,7 @@ mod sql_guard;
 
 use crate::db_manager::DatabaseManager;
 use crate::handler::RbdcDatabaseHandler;
-use rmcp::{ServiceExt, transport::stdio};
+use rmcp::{transport::stdio, ServiceExt};
 
 /// Command line arguments
 #[derive(Parser, Debug)]
@@ -33,7 +33,7 @@ struct Args {
     #[arg(long, default_value = "info")]
     log_level: String,
 
-    /// Enforce read-only server mode (blocks sql_exec)
+    /// Enforce read-only server mode and abort startup if the current database session cannot be validated as read-only.
     #[arg(long, default_value_t = false)]
     read_only: bool,
 }
@@ -45,9 +45,11 @@ async fn main() -> Result<(), anyhow::Error> {
     // Initialize logging
     tracing_subscriber::fmt()
         .with_env_filter(
-            EnvFilter::from_default_env()
-                .add_directive(args.log_level.parse()
-                    .unwrap_or_else(|_| tracing::Level::INFO.into()))
+            EnvFilter::from_default_env().add_directive(
+                args.log_level
+                    .parse()
+                    .unwrap_or_else(|_| tracing::Level::INFO.into()),
+            ),
         )
         .with_writer(std::io::stderr)
         .with_ansi(false)
@@ -57,28 +59,46 @@ async fn main() -> Result<(), anyhow::Error> {
     info!("Database URL: {}", args.database_url);
     info!("Read-only mode: {}", args.read_only);
 
-    // Create database manager
-    let db_manager = DatabaseManager::new(&args.database_url)
-        .map_err(|e| {
-            error!("Failed to create database manager: {}", e);
-            anyhow::Error::msg(e.to_string())
-        })?;
-    
-    // Configure connection pool
-    db_manager.configure_pool(args.max_connections, args.timeout).await;
-    
-    // Test database connection
-    db_manager.test_connection().await
-        .map_err(|e| anyhow::Error::msg(format!("Database connection test failed: {}", e)))?;
-    
-    info!("Database connection test successful");
+    // Create database manager (no connection yet)
+    let db_manager = DatabaseManager::new(&args.database_url, args.read_only).map_err(|e| {
+        error!("Failed to create database manager: {}", e);
+        anyhow::Error::msg(e.to_string())
+    })?;
 
-    // Create RBDC database handler
-    let handler = RbdcDatabaseHandler::new(Arc::new(db_manager), args.read_only);
+    // Configure connection pool
+    db_manager
+        .configure_pool(args.max_connections, args.timeout)
+        .await;
+
+    let db_manager = Arc::new(db_manager);
+
+    // Test DB connection in background — do NOT block MCP startup.
+    // Claude Desktop's initialize request must be answered within ~60s or it times out.
+    {
+        let db = Arc::clone(&db_manager);
+        tokio::spawn(async move {
+            match db.test_connection().await {
+                Ok(()) => {
+                    info!("Database connection test successful");
+                    match db.validate_read_only_session().await {
+                        Ok(()) => {
+                            if let Some(notice) = db.read_only_startup_notice() {
+                                tracing::warn!("{}", notice);
+                            }
+                        }
+                        Err(e) => error!("Read-only session validation failed: {}", e),
+                    }
+                }
+                Err(e) => error!("Database connection test failed: {}", e),
+            }
+        });
+    }
+
+    // Start MCP server immediately so initialize is handled without delay
+    let handler = RbdcDatabaseHandler::new(db_manager);
 
     info!("Starting RBDC MCP Server...");
-    
-    // Start server
+
     let service = handler.serve(stdio()).await.inspect_err(|e| {
         error!("Server startup failed: {:?}", e);
     })?;

--- a/src/sql_guard.rs
+++ b/src/sql_guard.rs
@@ -1,0 +1,213 @@
+use std::borrow::Cow;
+
+const READ_ONLY_START_KEYWORDS: &[&str] = &[
+    "SELECT",
+    "SHOW",
+    "DESC",
+    "DESCRIBE",
+    "EXPLAIN",
+    "WITH",
+];
+
+const WRITE_KEYWORDS: &[&str] = &[
+    "INSERT",
+    "UPDATE",
+    "DELETE",
+    "UPSERT",
+    "REPLACE",
+    "MERGE",
+    "CREATE",
+    "ALTER",
+    "DROP",
+    "TRUNCATE",
+    "GRANT",
+    "REVOKE",
+    "COMMIT",
+    "ROLLBACK",
+    "BEGIN",
+    "START",
+    "VACUUM",
+    "ANALYZE",
+    "ATTACH",
+    "DETACH",
+    "PRAGMA",
+    "EXEC",
+    "EXECUTE",
+    "CALL",
+    "DO",
+    "SET",
+    "USE",
+    "LOCK",
+    "UNLOCK",
+];
+
+fn is_ident_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '_'
+}
+
+fn is_escaped(sql: &[char], pos: usize) -> bool {
+    if pos == 0 {
+        return false;
+    }
+    let mut backslashes = 0usize;
+    let mut i = pos;
+    while i > 0 {
+        i -= 1;
+        if sql[i] == '\\' {
+            backslashes += 1;
+        } else {
+            break;
+        }
+    }
+    backslashes % 2 == 1
+}
+
+fn collect_uppercase_words_and_semicolons(sql: &str) -> (Vec<String>, usize) {
+    let chars: Vec<char> = sql.chars().collect();
+    let mut i = 0usize;
+    let mut words = Vec::new();
+    let mut semicolons = 0usize;
+
+    while i < chars.len() {
+        let c = chars[i];
+        let next = if i + 1 < chars.len() {
+            Some(chars[i + 1])
+        } else {
+            None
+        };
+
+        if c.is_whitespace() {
+            i += 1;
+            continue;
+        }
+
+        if c == '-' && next == Some('-') {
+            i += 2;
+            while i < chars.len() && chars[i] != '\n' {
+                i += 1;
+            }
+            continue;
+        }
+
+        if c == '/' && next == Some('*') {
+            i += 2;
+            while i + 1 < chars.len() {
+                if chars[i] == '*' && chars[i + 1] == '/' {
+                    i += 2;
+                    break;
+                }
+                i += 1;
+            }
+            continue;
+        }
+
+        if c == '\'' || c == '"' || c == '`' {
+            let quote = c;
+            i += 1;
+            while i < chars.len() {
+                if chars[i] == quote && !is_escaped(&chars, i) {
+                    i += 1;
+                    break;
+                }
+                i += 1;
+            }
+            continue;
+        }
+
+        if c == ';' {
+            semicolons += 1;
+            i += 1;
+            continue;
+        }
+
+        if is_ident_char(c) {
+            let start = i;
+            i += 1;
+            while i < chars.len() && is_ident_char(chars[i]) {
+                i += 1;
+            }
+            let token: Cow<'_, str> = chars[start..i].iter().collect::<String>().into();
+            words.push(token.to_ascii_uppercase());
+            continue;
+        }
+
+        i += 1;
+    }
+
+    (words, semicolons)
+}
+
+pub fn is_read_only_sql(sql: &str) -> bool {
+    let trimmed = sql.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    let (words, semicolons) = collect_uppercase_words_and_semicolons(trimmed);
+    if words.is_empty() {
+        return false;
+    }
+
+    if semicolons > 1 {
+        return false;
+    }
+
+    if semicolons == 1 && !trimmed.ends_with(';') {
+        return false;
+    }
+
+    let first = words.first().map(|s| s.as_str()).unwrap_or_default();
+    if !READ_ONLY_START_KEYWORDS.contains(&first) {
+        return false;
+    }
+
+    for word in &words {
+        if WRITE_KEYWORDS.contains(&word.as_str()) {
+            return false;
+        }
+    }
+
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_read_only_sql;
+
+    #[test]
+    fn allows_plain_select() {
+        assert!(is_read_only_sql("SELECT * FROM users"));
+    }
+
+    #[test]
+    fn allows_select_with_string_semicolon() {
+        assert!(is_read_only_sql("SELECT ';' AS semi"));
+    }
+
+    #[test]
+    fn allows_explain_select() {
+        assert!(is_read_only_sql("EXPLAIN SELECT * FROM users"));
+    }
+
+    #[test]
+    fn rejects_delete() {
+        assert!(!is_read_only_sql("DELETE FROM users WHERE id = 1"));
+    }
+
+    #[test]
+    fn rejects_comment_prefixed_delete() {
+        assert!(!is_read_only_sql("-- note\nDELETE FROM users"));
+    }
+
+    #[test]
+    fn rejects_multi_statement() {
+        assert!(!is_read_only_sql("SELECT * FROM users; DELETE FROM users"));
+    }
+
+    #[test]
+    fn rejects_write_cte() {
+        assert!(!is_read_only_sql(
+            "WITH moved AS (DELETE FROM users RETURNING *) SELECT * FROM moved"
+        ));
+    }
+}

--- a/src/sql_guard.rs
+++ b/src/sql_guard.rs
@@ -1,44 +1,12 @@
 use std::borrow::Cow;
 
-const READ_ONLY_START_KEYWORDS: &[&str] = &[
-    "SELECT",
-    "SHOW",
-    "DESC",
-    "DESCRIBE",
-    "EXPLAIN",
-    "WITH",
-];
+const READ_ONLY_START_KEYWORDS: &[&str] =
+    &["SELECT", "SHOW", "DESC", "DESCRIBE", "EXPLAIN", "WITH"];
 
 const WRITE_KEYWORDS: &[&str] = &[
-    "INSERT",
-    "UPDATE",
-    "DELETE",
-    "UPSERT",
-    "REPLACE",
-    "MERGE",
-    "CREATE",
-    "ALTER",
-    "DROP",
-    "TRUNCATE",
-    "GRANT",
-    "REVOKE",
-    "COMMIT",
-    "ROLLBACK",
-    "BEGIN",
-    "START",
-    "VACUUM",
-    "ANALYZE",
-    "ATTACH",
-    "DETACH",
-    "PRAGMA",
-    "EXEC",
-    "EXECUTE",
-    "CALL",
-    "DO",
-    "SET",
-    "USE",
-    "LOCK",
-    "UNLOCK",
+    "INSERT", "UPDATE", "DELETE", "UPSERT", "REPLACE", "MERGE", "CREATE", "ALTER", "DROP",
+    "TRUNCATE", "GRANT", "REVOKE", "COMMIT", "ROLLBACK", "BEGIN", "START", "VACUUM", "ANALYZE",
+    "ATTACH", "DETACH", "PRAGMA", "EXEC", "EXECUTE", "CALL", "DO", "SET", "USE", "LOCK", "UNLOCK",
 ];
 
 fn is_ident_char(c: char) -> bool {
@@ -190,6 +158,11 @@ mod tests {
     }
 
     #[test]
+    fn allows_single_select_with_trailing_semicolon() {
+        assert!(is_read_only_sql("SELECT * FROM users;"));
+    }
+
+    #[test]
     fn rejects_delete() {
         assert!(!is_read_only_sql("DELETE FROM users WHERE id = 1"));
     }
@@ -209,5 +182,15 @@ mod tests {
         assert!(!is_read_only_sql(
             "WITH moved AS (DELETE FROM users RETURNING *) SELECT * FROM moved"
         ));
+    }
+
+    #[test]
+    fn rejects_empty_sql() {
+        assert!(!is_read_only_sql("   "));
+    }
+
+    #[test]
+    fn allows_select_with_write_keyword_in_identifier() {
+        assert!(is_read_only_sql("SELECT \"DELETE\" AS action"));
     }
 }


### PR DESCRIPTION
## Problem

When the database connection is slow or hangs during startup, Claude Desktop's 60-second `initialize` timeout fires before the MCP handshake completes. The server was blocking the stdio loop while testing the DB connection.

Also, the advertised protocol version `V_2024_11_05` caused Claude Desktop to not recognize the server correctly.

## Changes

- **Move DB connection test to background task**: The MCP server now starts immediately and responds to `initialize` without waiting for the DB. The connection is tested asynchronously; tool calls will return an error if the DB isn't ready yet.
- **Update protocol version to `LATEST`** (2025-06-18): Aligns with what Claude Desktop expects.
- Bump version to 0.1.8

## Test

Start the server with a slow/unreachable DB — Claude Desktop completes the handshake and the tools appear. Queries return a clear error until the DB is reachable.

> **Note:** This PR depends on `fix/read-only-strict-mode` which introduces `sql_guard.rs`. It targets `main` — if you'd prefer to review them together or separately, happy to rebase.